### PR TITLE
Fix a quick typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ class Animal {
     }
 }
 
-class Dod: Animal {
+class Dog: Animal {
     override func run() { // used
     }
 }


### PR DESCRIPTION
Hey! Just checked out this project and noticed there was a typo in the English version of the README - "Dog" was misspelled as "Dod". Figured I would submit a quick pull request, let me know if I need to do anything else here.

Thanks!