### PR TITLE
Fix running from Terminal

### DIFF
--- a/Sources/Pecker/main.swift
+++ b/Sources/Pecker/main.swift
@@ -25,15 +25,14 @@ fileprivate func main(_ arguments: [String]) -> Int32 {
     }
 }
 
-private func createConfiguration(options: CommandLineOptions) throws -> Configuration {
-    let processInfo = ProcessInfo()
-    /// Find the index path, default is   ~Library/Developer/Xcode/DerivedData/<target>/Index/DataStore
-    let buildRoot = try processInfo.environmentVariable(name: EnvironmentKeys.buildRoot)
-    
+private func createConfiguration(options: CommandLineOptions) throws -> Configuration {    
     let indexStorePath: AbsolutePath
     if let indexStorePathString = options.indexStorePath {
         indexStorePath = AbsolutePath(indexStorePathString)
     } else {
+        let processInfo = ProcessInfo()
+        // Find the index path, default is   ~Library/Developer/Xcode/DerivedData/<target>/Index/DataStore
+        let buildRoot = try processInfo.environmentVariable(name: EnvironmentKeys.buildRoot)
         let buildRootPath = AbsolutePath(buildRoot)
         indexStorePath = buildRootPath.parentDirectory.parentDirectory.appending(component: "Index/DataStore")
     }


### PR DESCRIPTION
Hi!

I was having the same issue as described in #33. I cloned the source and did some debugging and think I found the bug. So here’s a PR that should fix it. It at least ran for me, although it reported a count of 0 for a very large codebase that most likely have some unused code.

When running from the terminal Pecker would fail with a `missingValue(argument: Optional("BUILD_ROOT"))` error. Even when the `-i` CLI parameter was provided. This moves the fallback logic to only run when a fallback needs to be found.