### PR TITLE
improve code performance

### DIFF
--- a/Sources/PeckerKit/Extensions/SymbolOccurrence+Extension.swift
+++ b/Sources/PeckerKit/Extensions/SymbolOccurrence+Extension.swift
@@ -5,12 +5,12 @@ extension SymbolOccurrence {
     
     /// Whether symbol is class, struct, enum, protocol extensions
     /// - Parameter sources: All the source extensions
-    func isSourceExtension(sources: inout [String: SourceDetail]) -> Bool {
-        if sources[self.identifier] != nil {
-            sources[self.identifier] = nil
-            return true
+    func isSourceExtension(safeSources: SafeSourceExtensions) -> Bool {
+        guard safeSources.value[self.identifier] != nil else {
+            return false
         }
-        return false
+        safeSources.atomically { $0[self.identifier] = nil }
+        return true
     }
 }
 

--- a/Sources/PeckerKit/SourceCollector.swift
+++ b/Sources/PeckerKit/SourceCollector.swift
@@ -1,64 +1,74 @@
 import Foundation
 import SwiftSyntax
 import TSCBasic
+
 public typealias FileSystem = TSCBasic.FileSystem
+typealias SafeSourceExtensions = ThreadSafe<[String: SourceDetail]>
 
 /// Collects source code in the path.
 class SourceCollector {
 
-    var sources: [SourceDetail] = []
-    var sourceExtensions: [String: SourceDetail] = [:]
+    let sourceExtensions = SafeSourceExtensions([:])
+    private(set) var sources: [SourceDetail] = []
     private let configuration: Configuration
     private let targetPath: AbsolutePath
-    private let excluded: [AbsolutePath]
-    private let included: [AbsolutePath]
-    private let blacklistFiles: [String]
+    private let excluded: Set<AbsolutePath>
+    private let included: Set<AbsolutePath>
+    private let blacklistFiles: Set<String>
     /// The file system to operate on.
     private let fs: FileSystem
     
     init(rootPath: AbsolutePath, configuration: Configuration) {
         self.targetPath = rootPath
         self.configuration = configuration
-        self.excluded = configuration.excluded
-        self.included = configuration.included
-        self.blacklistFiles = configuration.blacklistFiles
+        self.excluded = Set(configuration.excluded)
+        self.included = Set(configuration.included)
+        self.blacklistFiles = Set(configuration.blacklistFiles)
         self.fs = localFileSystem
     }
 
     /// Populates the internal collections form the path source code
     /// Currently only supports Swift
-    func collect() throws {
+    func collect() {
         let files = computeContents()
-        for file in files {
-            let syntax = try SyntaxParser.parse(file.asURL)
+        let safeSources = ThreadSafe<[SourceDetail]>([])
+        DispatchQueue.concurrentPerform(iterations: files.count) { index in
+            guard let syntax = try? SyntaxParser.parse(files[index].asURL) else {
+                return
+            }
             let context = CollectContext(configuration: configuration,
-                                         filePath: file.description,
+                                         filePath: files[index].description,
                                          sourceFileSyntax: syntax)
             var pipeline = SwiftSourceCollectPipeline(context: context)
             syntax.walk(&pipeline)
-            sources += pipeline.sources
-            sourceExtensions += pipeline.sourceExtensions
+            safeSources.atomically { $0 += pipeline.sources }
+            sourceExtensions.atomically { $0 += pipeline.sourceExtensions }
         }
+        sources = safeSources.value
     }
-    
+
     /// Compute the contents of the files in a target.
     ///
     /// This avoids recursing into certain directories like exclude.
     private func computeContents() -> [AbsolutePath] {
         var contents: [AbsolutePath] = []
         var queue: [AbsolutePath] = [targetPath]
-        
+
         while let curr = queue.popLast() {
             
             // Ignore if this is an excluded path.
             if self.excluded.contains(curr) { continue }
             
             // Append and continue if the path doesn't have an extension or is not a directory and is not in lacklistFiles.
-            if curr.extension == "swift" && !fs.isDirectory(curr) && !blacklistFiles.contains(curr.basenameWithoutExt) {
+            if curr.extension == "swift" && !blacklistFiles.contains(curr.basenameWithoutExt) {
                 contents.append(curr)
                 continue
             }
-            
+            // If not directory continue
+            guard fs.isDirectory(curr) else {
+                continue
+            }
+
             do {
                 // Add directory content to the queue.
                 let dirContents = try fs.getDirectoryContents(curr).map{ curr.appending(component: $0) }
@@ -67,7 +77,7 @@ class SourceCollector {
                 log(error.localizedDescription, level: .warning)
             }
         }
-        
+
         return contents
     }
 }

--- a/Sources/PeckerKit/SourceKitServer/SourceKitServer.swift
+++ b/Sources/PeckerKit/SourceKitServer/SourceKitServer.swift
@@ -3,7 +3,7 @@ import IndexStoreDB
 
 class SourceKitServer {
     
-    var workspace: Workspace?
+    let workspace: Workspace?
     
     init(workspace: Workspace? = nil) {
         self.workspace = workspace

--- a/Sources/PeckerKit/Utils/ThreadSafe.swift
+++ b/Sources/PeckerKit/Utils/ThreadSafe.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+final class ThreadSafe<A> {
+    private var _value: A
+    private let queue = DispatchQueue(label: "com.peckerKit.threadSafeSerialQueue")
+
+    init(_ value: A) {
+        self._value = value
+    }
+
+    var value: A {
+        return queue.sync { _value }
+    }
+
+    func atomically(_ transform: (inout A) -> ()) {
+        queue.sync {
+            transform(&self._value)
+        }
+    }
+}

--- a/Sources/PeckerKit/XMLServer/XMLServer.swift
+++ b/Sources/PeckerKit/XMLServer/XMLServer.swift
@@ -4,7 +4,7 @@ import TSCBasic
 class XMLServer {
     
     private let targetPath: AbsolutePath
-    private let excluded: [AbsolutePath]
+    private let excluded: Set<AbsolutePath>
     private let included: [AbsolutePath]
     /// The file system to operate on.
     private let fs: FileSystem
@@ -13,7 +13,7 @@ class XMLServer {
     
     init(rootPath: AbsolutePath, configuration: Configuration) {
         self.targetPath = rootPath
-        self.excluded = configuration.excluded
+        self.excluded = Set(configuration.excluded)
         self.included = configuration.included
         self.fs = localFileSystem
     }
@@ -39,12 +39,17 @@ class XMLServer {
             // Ignore if this is an excluded path.
             if self.excluded.contains(curr) { continue }
             
-            // Append and continue if the path doesn't have an extension or is not a directory.
-            if (curr.extension == "xib" || curr.extension == "storyboard" ) && !fs.isDirectory(curr) {
+            // Append and continue if the path has an extension
+            if (curr.extension == "xib" || curr.extension == "storyboard" ) {
                 contents.append(curr)
                 continue
             }
-            
+
+            // If not directory continue
+            guard fs.isDirectory(curr) else {
+                continue
+            }
+
             do {
                 // Add directory content to the queue.
                 let dirContents = try fs.getDirectoryContents(curr).map{ curr.appending(component: $0) }


### PR DESCRIPTION
Hello, @woshiccm and thanks for your great work!

I have run pecker for one very big project (about 16k of source elements classes, funcs etc) and for my mac mini (Mac mini (2018) 3 GHz Intel Core i5 16 ГБ 2667 MHz DDR4) it took 147 seconds to process and it found 300 warnings (about 1-2% of them false positive – but still it is an incredible result!). 

But I thought that there may be something to optimize. And after researching pecker execution with Time Profiler I found some long-time methods and improved them. Then I run pecker for same configs and project and it took 34.9 seconds (and 300 same warnings).

In this 35 seconds – 95% of time takes 16k times .forEachCanonicalSymbolOccurrence execution which is implemented in IndexStoreDB. (not sure if there is something that we can do with it)
 