### PR TITLE
Support Swift 5.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
         "package": "IndexStoreDB",
         "repositoryURL": "https://github.com/apple/indexstore-db.git",
         "state": {
-          "branch": "swift-5.2-branch",
-          "revision": "99472b2b84b1e72f0bf4b55f2ba0b921b16ed945",
+          "branch": "release/5.3",
+          "revision": "58b306e0274155911dd4957945fd7e630798fec5",
           "version": null
         }
       },
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "0688b9cfc4c3dd234e4f55f1f056b2affc849873",
-          "version": "0.50200.0"
+          "revision": "844574d683f53d0737a9c6d706c3ef31ed2955eb",
+          "version": "0.50300.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,8 @@ let package = Package(
         .executable(name: "pecker", targets: ["Pecker"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50200.0")),
-        .package(url: "https://github.com/apple/indexstore-db.git", .branch("swift-5.2-branch")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50300.0")),
+        .package(url: "https://github.com/apple/indexstore-db.git", .branch("release/5.3")),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("master")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .branch("master")),


### PR DESCRIPTION
The latest version is failing on my project with the error "SwiftSyntax parser library isn't compatible". This change adds logging so errors like this are surfaced to users, and updates dependencies to support Xcode12/Swift5.3

Thanks @woshiccm for the helpful tool!