### PR TITLE
Fix dependency requirement of `swift-argument-parser` to specific version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(url: "https://github.com/apple/indexstore-db.git", .branch("release/5.3")),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .branch("main")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", .branch("main")),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .exact("0.3.2")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
This PR fixes compilation failure of dependency `swift-argument-parser` by changing its dependency requirement to specific version rather than the main branch.

More specifically, closing this PR (https://github.com/apple/swift-argument-parser/pull/262) led to compilation failure, so we have to see the version (`0.3.2`) which does not contain these changes.

The same changes should apply to `swift-tools-support-core` if needed, but not now as it compiles as is.